### PR TITLE
fix module.ts error if no statements in file

### DIFF
--- a/src/rules/module.ts
+++ b/src/rules/module.ts
@@ -25,7 +25,7 @@ export const module = makeRule<[], "moduleViolation">({
 				const tsNode = service.esTreeNodeToTSNodeMap.get(node);
 				if (tsNode.externalModuleIndicator === undefined) {
 					context.report({
-						node: node.body[0],
+						node,
 						messageId: "moduleViolation",
 						fix: (fixer) => fixer.insertTextBefore(node, "export {};\n"),
 					});


### PR DESCRIPTION
`node.body[0]` will be undefined if there are no statements in a file, which causes an error. It also misleadingly highlights the first line, even though that line is not specifically wrong.