### PR TITLE
Disable @typescript-eslint/no-array-constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ export = makePlugin({
 				"@typescript-eslint/ban-types": "off",
 				"@typescript-eslint/explicit-function-return-type": "off",
 				"@typescript-eslint/explicit-module-boundary-types": "off",
+				"@typescript-eslint/no-array-constructor": "off",
 				"@typescript-eslint/no-empty-function": "off",
 				"@typescript-eslint/no-empty-interface": "off",
 				"@typescript-eslint/no-namespace": "off",


### PR DESCRIPTION
This lint does not understand the roblox-ts Array constructor typing, and the autofix will produce **broken behaviour code**. The rule should absolutely be disabled.