### PR TITLE
Add eslint:recommended to template config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Make a file named `.eslintrc` and place this in the contents. If you have a pre-
         "prettier"
     ],
     "extends": [
+        "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         "prettier/@typescript-eslint",
         "plugin:prettier/recommended",


### PR DESCRIPTION
This seems to be omitted by mistake, meaning that a lot of the base rules of eslint remain disabled.