### PR TITLE
Remove prettier/@typescript-eslint extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Make a file named `.eslintrc` and place this in the contents. If you have a pre-
     ],
     "extends": [
         "plugin:@typescript-eslint/recommended",
-        "prettier/@typescript-eslint",
         "plugin:prettier/recommended",
         "plugin:roblox-ts/recommended"
     ],


### PR DESCRIPTION
No longer necessary since eslint-config-prettier v8.0.0