### PR TITLE
fix: only apply plugin rules to typescript files in subdirectories

### DIFF
--- a/fixtures/eslint-v8/.eslintrc
+++ b/fixtures/eslint-v8/.eslintrc
@@ -1,7 +1,8 @@
 // ESLint v8 Legacy Config
 {
   "extends": [
-    "eslint:recommended"
+    "eslint:recommended",
+    "plugin:roblox-ts/recommended-legacy"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -10,27 +11,12 @@
     "project": "./tsconfig.json"
   },
   "plugins": [
-    "@typescript-eslint",
-    "roblox-ts"
+    "@typescript-eslint"
   ],
   "rules": {
     // TypeScript ESLint rules
     "@typescript-eslint/no-unused-vars": "error",
-    "@typescript-eslint/no-explicit-any": "off",
-
-    // Roblox-TS plugin rules - covering different rule types
-    "roblox-ts/no-null": "error",
-    "roblox-ts/no-object-math": "error",
-    "roblox-ts/no-array-pairs": "error",
-    "roblox-ts/lua-truthiness": "error",
-    "roblox-ts/no-any": ["error", { "fixToUnknown": true }],
-    "roblox-ts/no-enum-merging": "error",
-    "roblox-ts/no-invalid-identifier": "error",
-    "roblox-ts/prefer-task-library": "error",
-    "roblox-ts/size-method": "error",
-    "roblox-ts/no-for-in": "error",
-    "roblox-ts/no-private-identifier": "error",
-    "roblox-ts/no-get-set": "error"
+    "@typescript-eslint/no-explicit-any": "off"
   },
   "ignorePatterns": ["dist/", "node_modules/"]
 }

--- a/fixtures/eslint-v8/config-test.ts
+++ b/fixtures/eslint-v8/config-test.ts
@@ -1,0 +1,19 @@
+// Root-level TypeScript file that should NOT trigger roblox-ts rules
+// This simulates a config file that would be at the project root
+
+// These violations should NOT be flagged by roblox-ts rules due to file constraint
+let nullValue = null; // no-null rule should NOT trigger
+let anyValue: any = "test"; // no-any rule should NOT trigger
+wait(1); // prefer-task-library rule should NOT trigger
+
+const obj = { a: 1, b: 2 };
+for (const key in obj) { // no-for-in rule should NOT trigger
+  // Process the key
+  const value = obj[key as keyof typeof obj];
+}
+
+export const testConfig = {
+  nullValue,
+  anyValue,
+  obj,
+};

--- a/fixtures/eslint-v9/config-test.ts
+++ b/fixtures/eslint-v9/config-test.ts
@@ -1,0 +1,19 @@
+// Root-level TypeScript file that should NOT trigger roblox-ts rules
+// This simulates a config file that would be at the project root
+
+// These violations should NOT be flagged by roblox-ts rules due to file constraint
+let nullValue = null; // no-null rule should NOT trigger
+let anyValue: any = "test"; // no-any rule should NOT trigger
+wait(1); // prefer-task-library rule should NOT trigger
+
+const obj = { a: 1, b: 2 };
+for (const key in obj) { // no-for-in rule should NOT trigger
+  // Process the key
+  const value = obj[key as keyof typeof obj];
+}
+
+export const testConfig = {
+  nullValue,
+  anyValue,
+  obj,
+};

--- a/fixtures/eslint-v9/eslint.config.ts
+++ b/fixtures/eslint-v9/eslint.config.ts
@@ -6,6 +6,7 @@ import robloxTs from 'eslint-plugin-roblox-ts';
 
 export default [
   js.configs.recommended,
+  robloxTs.configs.recommended,
   {
     files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
@@ -13,32 +14,21 @@ export default [
       parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module',
-        project: './tsconfig.json',
+        projectService: {
+					allowDefaultProject: ["*.ts"],
+					defaultProject: "./tsconfig.json",
+				},
       },
     },
     plugins: {
       '@typescript-eslint': typescript,
-      'roblox-ts': robloxTs,
     },
     rules: {
       '@typescript-eslint/no-unused-vars': 'error',
       '@typescript-eslint/no-explicit-any': 'off',
-      
-      // Roblox-TS plugin rules - covering different rule types
-      'roblox-ts/no-null': 'error',
-      'roblox-ts/no-object-math': 'error',
-      'roblox-ts/no-array-pairs': 'error',
-      'roblox-ts/lua-truthiness': 'error',
-      'roblox-ts/no-any': ['error', { fixToUnknown: true }],
-      'roblox-ts/no-enum-merging': 'error',
-      'roblox-ts/no-invalid-identifier': 'error',
-      'roblox-ts/prefer-task-library': 'error',
-      'roblox-ts/size-method': 'error',
-      'roblox-ts/no-for-in': 'error',
-      'roblox-ts/no-private-identifier': 'error',
-      'roblox-ts/no-get-set': 'error',
     },
   },
+
   {
     files: ['**/*.js'],
     languageOptions: {

--- a/scripts/test-fixtures.ts
+++ b/scripts/test-fixtures.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env tsx
-
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 interface ESLintMessage {
@@ -24,23 +22,12 @@ interface FixtureTest {
 	version: string;
 }
 
-const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as { name: string };
-const projectName = packageJson.name;
-
-/** Expected roblox-ts rules that should be triggered in fixtures. */
-const EXPECTED_RULES = [
-	"roblox-ts/no-null",
-	"roblox-ts/no-any",
-	"roblox-ts/no-object-math",
-	"roblox-ts/no-array-pairs",
-	"roblox-ts/lua-truthiness",
-	"roblox-ts/no-enum-merging",
-	"roblox-ts/prefer-task-library",
-	"roblox-ts/size-method",
-	"roblox-ts/no-for-in",
-	"roblox-ts/no-private-identifier",
-	"roblox-ts/no-get-set",
-];
+interface TestResult {
+	details?: string;
+	duration?: number;
+	name: string;
+	passed: boolean;
+}
 
 /**
  * Extract and analyze roblox-ts messages from ESLint results.
@@ -57,9 +44,44 @@ function analyzeESLintResults(results: Array<ESLintResult>) {
 	return { allMessages, robloxTsMessages };
 }
 
+const testResults: Array<TestResult> = [];
+
+/**
+ * Handle ESLint execution error for fixtures.
+ *
+ * @param err - The error from ESLint execution.
+ * @param fixtureName - Name of the fixture being tested.
+ * @returns True if error handling succeeded, false otherwise.
+ */
+function handleFixtureError(err: unknown, fixtureName: string): boolean {
+	const stdout = (err as { stdout?: string }).stdout ?? "";
+
+	if (stdout.trim() === "") {
+		testResults.push({
+			details: "No ESLint output received",
+			name: `${fixtureName} fixture`,
+			passed: false,
+		});
+		return false;
+	}
+
+	try {
+		const results = JSON.parse(stdout) as Array<ESLintResult>;
+		return validateResults(results, fixtureName);
+	} catch (err_) {
+		const errorMessage = err_ instanceof Error ? err_.message : String(err_);
+		testResults.push({
+			details: `Failed to parse ESLint output: ${errorMessage}`,
+			name: `${fixtureName} fixture`,
+			passed: false,
+		});
+		return false;
+	}
+}
+
 /** Main test function that runs all fixture tests. */
 function main(): never {
-	console.log(`🚀 Testing ${projectName} fixtures\n`);
+	const startTime = Date.now();
 
 	const fixtures: Array<FixtureTest> = [
 		{ name: "eslint-plugin-roblox-ts-fixture-v8", version: "v8" },
@@ -69,22 +91,84 @@ function main(): never {
 	let allPassed = true;
 
 	for (const { name, version } of fixtures) {
-		const passed = testFixture(name, version);
-		if (!passed) {
+		const fixturesPassed = testFixture(name, version);
+		const constraintPassed = testFileConstraint(name, version);
+
+		if (!fixturesPassed || !constraintPassed) {
 			allPassed = false;
 		}
 	}
 
-	console.log("\n" + "=".repeat(50));
+	const duration = Date.now() - startTime;
+	printTestSummary(allPassed, duration);
+
+	process.exit(allPassed ? 0 : 1);
+}
+
+/**
+ * Display a formatted summary of test results including pass/fail status,
+ * individual test outcomes, and execution time.
+ *
+ * @param allPassed - Whether all tests passed.
+ * @param duration - Test duration in milliseconds.
+ */
+function printTestSummary(allPassed: boolean, duration: number): void {
+	const status = allPassed ? "PASS" : "FAIL";
+	console.log(`${status}  fixture tests`);
+	console.log("");
+
+	for (const result of testResults) {
+		const symbol = result.passed ? "✓" : "✗";
+		const details = result.details !== undefined ? ` (${result.details})` : "";
+		console.log(`${symbol} ${result.name}${details}`);
+	}
+
+	console.log("");
+
+	const passed = testResults.filter((result) => result.passed).length;
+	const total = testResults.length;
+	const failed = total - passed;
 
 	if (allPassed) {
-		console.log("✅ All fixture tests passed!");
-		console.log("🎉 Plugin works correctly with both ESLint v8 and v9");
-		process.exit(0);
+		console.log(`Tests: ${passed} passed, ${total} total`);
 	} else {
-		console.log("❌ Some fixture tests failed");
-		process.exit(1);
+		console.log(`Tests: ${failed} failed, ${passed} passed, ${total} total`);
 	}
+
+	console.log(`Time:  ${(duration / 1000).toFixed(1)}s`);
+}
+
+/**
+ * Record a constraint test failure.
+ *
+ * @param robloxTsMessages - Array of roblox-ts rule violation messages.
+ * @param fixtureName - Name of the fixture being tested.
+ */
+function recordConstraintFailure(
+	robloxTsMessages: Array<ESLintMessage>,
+	fixtureName: string,
+): void {
+	const triggeredRules = robloxTsMessages
+		.map((message) => message.ruleId)
+		.filter((ruleId): ruleId is string => ruleId !== undefined);
+	const details = `Root-level file triggered ${robloxTsMessages.length} roblox-ts rules: ${triggeredRules.join(", ")}`;
+	testResults.push({
+		details,
+		name: `${fixtureName} file constraints`,
+		passed: false,
+	});
+}
+
+/**
+ * Record a constraint test success.
+ *
+ * @param fixtureName - Name of the fixture being tested.
+ */
+function recordConstraintSuccess(fixtureName: string): void {
+	testResults.push({
+		name: `${fixtureName} file constraints`,
+		passed: true,
+	});
 }
 
 /**
@@ -103,6 +187,38 @@ function runESLintOnFixture(eslintVersion: string): string {
 }
 
 /**
+ * Run ESLint on root-level config file to test file constraint.
+ *
+ * @param eslintVersion - ESLint version being tested (v8 or v9).
+ * @returns ESLint JSON output as string.
+ */
+function runESLintOnRootFile(eslintVersion: string): string {
+	const fixtureDirectory = join("fixtures", eslintVersion === "v8" ? "eslint-v8" : "eslint-v9");
+
+	return execSync(`cd ${fixtureDirectory} && npx eslint config-test.ts --format json`, {
+		encoding: "utf8",
+		stdio: "pipe",
+	});
+}
+
+/**
+ * Test file constraint - verify root-level files don't trigger roblox-ts rules.
+ *
+ * @param fixtureName - Name of the fixture package to test.
+ * @param eslintVersion - ESLint version being tested (v8 or v9).
+ * @returns True if constraint test passed, false otherwise.
+ */
+function testFileConstraint(fixtureName: string, eslintVersion: string): boolean {
+	try {
+		const stdout = runESLintOnRootFile(eslintVersion);
+		return validateConstraintResults(stdout, fixtureName);
+	} catch (err) {
+		const stdout = (err as { stdout?: string }).stdout ?? "";
+		return validateConstraintResults(stdout, fixtureName);
+	}
+}
+
+/**
  * Test a specific fixture.
  *
  * @param fixtureName - Name of the fixture package to test.
@@ -110,35 +226,57 @@ function runESLintOnFixture(eslintVersion: string): string {
  * @returns True if test passed, false otherwise.
  */
 function testFixture(fixtureName: string, eslintVersion: string): boolean {
-	console.log(`\n🧪 Testing ${fixtureName} (ESLint ${eslintVersion})`);
-
 	try {
 		runESLintOnFixture(eslintVersion);
 		// If ESLint succeeds (no errors), that's unexpected for our test fixtures
-		console.error(
-			`❌ Expected ESLint to find violations in ${fixtureName}, but none were found`,
-		);
+		testResults.push({
+			details: "Expected violations but none were found",
+			name: `${fixtureName} fixture`,
+			passed: false,
+		});
 		return false;
 	} catch (err) {
 		// ESLint failed (found errors) - this is expected!
-		const stdout = (err as { stdout?: string }).stdout ?? "";
+		return handleFixtureError(err, fixtureName);
+	}
+}
 
-		if (stdout.trim() === "") {
-			console.error(`❌ No ESLint output received for ${fixtureName}`);
+/**
+ * Validate constraint test results to ensure no roblox-ts rules were triggered.
+ *
+ * @param stdout - ESLint output to validate.
+ * @param fixtureName - Name of the fixture being tested.
+ * @returns True if constraint validation passed, false otherwise.
+ */
+function validateConstraintResults(stdout: string, fixtureName: string): boolean {
+	if (stdout.trim() === "") {
+		testResults.push({
+			details: "No ESLint output received",
+			name: `${fixtureName} file constraints`,
+			passed: false,
+		});
+		return false;
+	}
+
+	try {
+		const results = JSON.parse(stdout) as Array<ESLintResult>;
+		const { robloxTsMessages } = analyzeESLintResults(results);
+
+		if (robloxTsMessages.length > 0) {
+			recordConstraintFailure(robloxTsMessages, fixtureName);
 			return false;
 		}
 
-		try {
-			const results = JSON.parse(stdout) as Array<ESLintResult>;
-			return validateResults(results, fixtureName, eslintVersion);
-		} catch (err_) {
-			console.error(
-				`❌ Failed to parse ESLint JSON output for ${fixtureName}:`,
-				(err_ as Error).message,
-			);
-			console.error("Raw output:", stdout.substring(0, 200) + "...");
-			return false;
-		}
+		recordConstraintSuccess(fixtureName);
+		return true;
+	} catch (err) {
+		const errorMessage = err instanceof Error ? err.message : String(err);
+		testResults.push({
+			details: `Failed to parse ESLint output: ${errorMessage}`,
+			name: `${fixtureName} file constraints`,
+			passed: false,
+		});
+		return false;
 	}
 }
 
@@ -147,44 +285,28 @@ function testFixture(fixtureName: string, eslintVersion: string): boolean {
  *
  * @param results - ESLint results array.
  * @param fixtureName - Name of the fixture being tested.
- * @param eslintVersion - ESLint version being tested.
  * @returns True if validation passed, false otherwise.
  */
-function validateResults(
-	results: Array<ESLintResult>,
-	fixtureName: string,
-	eslintVersion: string,
-): boolean {
-	const { allMessages, robloxTsMessages } = analyzeESLintResults(results);
-
-	console.log(`   📊 Found ${allMessages.length} total violations`);
-	console.log(`   🎯 Found ${robloxTsMessages.length} roblox-ts violations`);
+function validateResults(results: Array<ESLintResult>, fixtureName: string): boolean {
+	const { robloxTsMessages } = analyzeESLintResults(results);
 
 	if (robloxTsMessages.length === 0) {
-		console.error(`❌ No roblox-ts rule violations found in ${fixtureName}`);
+		testResults.push({
+			details: "No roblox-ts rule violations found",
+			name: `${fixtureName} fixture`,
+			passed: false,
+		});
 		return false;
 	}
 
-	// Check that we have violations from our expected rules
-	const foundRules = new Set(
-		robloxTsMessages
-			.map((message) => message.ruleId)
-			.filter((ruleId): ruleId is string => ruleId !== undefined),
-	);
-	const missingRules = EXPECTED_RULES.filter((rule) => !foundRules.has(rule));
-
-	if (missingRules.length > 0) {
-		console.warn(
-			`⚠️  Some expected rules not triggered in ${fixtureName}: ${missingRules.join(", ")}`,
-		);
-	}
-
-	// Verify plugin loaded correctly by checking we have roblox-ts violations
-	const foundRulesArray = Array.from(foundRules);
-	console.log(`   ✅ Triggered rules: ${foundRulesArray.join(", ")}`);
-
 	// Success if we found roblox-ts violations
-	console.log(`   ✅ ${fixtureName} working correctly with ESLint ${eslintVersion}`);
+	const details = `${robloxTsMessages.length} roblox-ts violations found`;
+	testResults.push({
+		details,
+		name: `${fixtureName} fixture`,
+		passed: true,
+	});
+
 	return true;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ import { sizeMethod } from "./rules/size-method/rule";
 
 const PLUGIN_NAME = packageName.replace(/^eslint-plugin-/, "");
 
+const TYPESCRIPT_FILES = ["**/*/*.?([cm])ts", "**/*/*.?([cm])tsx"];
+
 /**
  * Generates a rules record where all plugin rules are set to "error".
  *
@@ -94,6 +96,7 @@ const configs = {
 	 * ```
 	 */
 	"recommended": {
+		files: TYPESCRIPT_FILES,
 		plugins: {
 			[PLUGIN_NAME]: plugin,
 		},
@@ -113,8 +116,13 @@ const configs = {
 	 * ```
 	 */
 	"recommended-legacy": {
+		overrides: [
+			{
+				files: TYPESCRIPT_FILES,
+				rules: allRules,
+			},
+		],
 		plugins: [PLUGIN_NAME],
-		rules: allRules,
 	} satisfies Linter.LegacyConfig,
 };
 


### PR DESCRIPTION
Add file constraints to prevent rules running on non-typescript files, as well as typescript files that reside in the root (e.g. config files).

Additionally, improve fixtures to use recommended configs directly and ensure non-root files do not get roblox rules applied.