### PR TITLE
feat(no-user-defined-lua-tuple): dont apply to declarations

### DIFF
--- a/src/rules/no-user-defined-lua-tuple/rule.spec.ts
+++ b/src/rules/no-user-defined-lua-tuple/rule.spec.ts
@@ -18,6 +18,33 @@ const valid: Array<ValidTestCase> = [
 		code: "const a = $tuple();",
 		options: [{ allowTupleMacro: true }],
 	},
+	"declare function externalFn(): LuaTuple<[string, boolean]>;",
+	unindent`
+		export declare const receive_full: {
+			call: () => LuaTuple<[buffer | undefined, Array<Array<unknown>>]>
+		};
+	`,
+	unindent`
+		interface MyClass {
+    		instanceProperty: string;
+    		instanceMethod(): LuaTuple<[number, string]>;
+		}
+
+		interface MyClassConstructor {
+    		new (): MyClass;
+    		staticProperty: string;
+    		staticMethod(): LuaTuple<[number, string]>;
+		}
+
+		declare const MyClass: MyClassConstructor;
+		export = MyClass;
+	`,
+	unindent`
+		declare class ExternalClass {
+			method(): LuaTuple<[number, string]>;
+			static staticMethod(): LuaTuple<[boolean]>;
+		}
+	`,
 ];
 
 const invalid: Array<InvalidTestCase> = [


### PR DESCRIPTION
Removes the no-user-defined-lua-tuple rule from applying to declarations, as these are most commonly used to allow users to interop with existing Luau (which is fine to use LuaTuple for).